### PR TITLE
don't delete DataChannerlObserver in OnStateChange

### DIFF
--- a/org/webrtc/wrapper/GlobalObserver.cc
+++ b/org/webrtc/wrapper/GlobalObserver.cc
@@ -321,12 +321,12 @@ namespace Org {
 							Windows::UI::Core::CoreDispatcherPriority::Normal,
 							ref new Windows::UI::Core::DispatchedHandler([this] {
 							_channel->OnClose();
-							delete this;
+							//delete this;
 						}));
 					}
 					else {
 						_channel->OnClose();
-						delete this;
+						//delete this;
 					}
 					break;
 				}


### PR DESCRIPTION
Don't delete DataChannerlObserver in OnStateChange, otherwise it will crash in RTCPeerConnection::~RTCPeerConnection, where it will be deleted again. 

Also see the comment in line 418 of PeerConnectionInterface.cc