### PR TITLE
Add new encoder factory for UWP MF encoder

### DIFF
--- a/third_party/winuwp_h264/winuwp_h264_factory.cc
+++ b/third_party/winuwp_h264/winuwp_h264_factory.cc
@@ -66,10 +66,16 @@ namespace webrtc {
     std::vector<SdpVideoFormat> formats = { 
       SdpVideoFormat(cricket::kH264CodecName, 
       {
-        //copy-pasted from h264.cc.
-        //specifies the h264 profile, in this case baseline. If we omit this, firefox 65
-        //rejects the video offer, so we send it like the built-in codec does.
-        {cricket::kH264FmtpProfileLevelId, "42100b"} 
+        //copy-pasted from h264.cc
+        {cricket::kH264FmtpProfileLevelId, "42100b"},
+        {cricket::kH264FmtpLevelAsymmetryAllowed, "1"},
+        {cricket::kH264FmtpPacketizationMode, "0"}
+      }),
+      SdpVideoFormat(cricket::kH264CodecName, 
+      {
+        {cricket::kH264FmtpProfileLevelId, "42100b"},
+        {cricket::kH264FmtpLevelAsymmetryAllowed, "1"},
+        {cricket::kH264FmtpPacketizationMode, "1"}
       }) 
     };
     return formats;

--- a/third_party/winuwp_h264/winuwp_h264_factory.cc
+++ b/third_party/winuwp_h264/winuwp_h264_factory.cc
@@ -18,34 +18,6 @@
 
 namespace webrtc {
 
-  WinUWPH264EncoderFactory::WinUWPH264EncoderFactory() {
-    codecList_ =
-      std::vector<cricket::VideoCodec> {
-        cricket::VideoCodec("H264")
-    };
-  }
-
-  webrtc::VideoEncoder* WinUWPH264EncoderFactory::CreateVideoEncoder(
-    const cricket::VideoCodec& codec) {
-    if (codec.name == "H264") {
-      return new WinUWPH264EncoderImpl();
-    } else {
-      return nullptr;
-    }
-  }
-
-  const std::vector<cricket::VideoCodec>&
-    WinUWPH264EncoderFactory::supported_codecs() const {
-    return codecList_;
-  }
-
-  void WinUWPH264EncoderFactory::DestroyVideoEncoder(
-    webrtc::VideoEncoder* encoder) {
-      encoder->Release();
-      delete encoder;
-  }
-
-
   webrtc::VideoDecoder* WinUWPH264DecoderFactory::CreateVideoDecoder(
     webrtc::VideoCodecType type) {
     if (type == kVideoCodecH264) {
@@ -61,7 +33,7 @@ namespace webrtc {
     delete decoder;
   }
 
-  std::vector<SdpVideoFormat> WinUWPH264EncoderFactoryNew::GetSupportedFormats()
+  std::vector<SdpVideoFormat> WinUWPH264EncoderFactory::GetSupportedFormats()
     const {
     std::vector<SdpVideoFormat> formats = { 
       SdpVideoFormat(cricket::kH264CodecName, 
@@ -81,17 +53,16 @@ namespace webrtc {
     return formats;
   }
 
-  VideoEncoderFactory::CodecInfo WinUWPH264EncoderFactoryNew::QueryVideoEncoder(
+  VideoEncoderFactory::CodecInfo WinUWPH264EncoderFactory::QueryVideoEncoder(
     const SdpVideoFormat& format) const {
     CodecInfo info;
-    //not sure about this. mf does support hw MFTs but doesn't really tell us
-    //when using sink writer. it's more of a "silent sw fallback if hw not available" thing
-    info.is_hardware_accelerated = false;
+    info.is_hardware_accelerated = true;
     info.has_internal_source = false;
+    
     return info;
   }
 
-  std::unique_ptr<VideoEncoder> WinUWPH264EncoderFactoryNew::CreateVideoEncoder(
+  std::unique_ptr<VideoEncoder> WinUWPH264EncoderFactory::CreateVideoEncoder(
     const SdpVideoFormat& format) {
     if (cricket::CodecNamesEq(format.name, cricket::kH264CodecName)) {
       return std::make_unique<WinUWPH264EncoderImpl>();

--- a/third_party/winuwp_h264/winuwp_h264_factory.cc
+++ b/third_party/winuwp_h264/winuwp_h264_factory.cc
@@ -63,7 +63,15 @@ namespace webrtc {
 
   std::vector<SdpVideoFormat> WinUWPH264EncoderFactoryNew::GetSupportedFormats()
     const {
-    std::vector<SdpVideoFormat> formats = { SdpVideoFormat("H264") };
+    std::vector<SdpVideoFormat> formats = { 
+      SdpVideoFormat(cricket::kH264CodecName, 
+      {
+        //copy-pasted from h264.cc.
+        //specifies the h264 profile, in this case baseline. If we omit this, firefox 65
+        //rejects the video offer, so we send it like the built-in codec does.
+        {cricket::kH264FmtpProfileLevelId, "42100b"} 
+      }) 
+    };
     return formats;
   }
 

--- a/third_party/winuwp_h264/winuwp_h264_factory.h
+++ b/third_party/winuwp_h264/winuwp_h264_factory.h
@@ -15,6 +15,7 @@
 #include "media/engine/webrtcvideoencoderfactory.h"
 #include "media/engine/webrtcvideodecoderfactory.h"
 #include "media/base/codec.h"
+#include "api/video_codecs/video_encoder_factory.h"
 
 namespace webrtc {
 
@@ -32,6 +33,16 @@ class WinUWPH264EncoderFactory : public cricket::WebRtcVideoEncoderFactory {
 
  private:
   std::vector<cricket::VideoCodec> codecList_;
+};
+
+class WinUWPH264EncoderFactoryNew : public VideoEncoderFactory {
+ public:
+  std::vector<SdpVideoFormat> GetSupportedFormats() const override;
+
+  CodecInfo QueryVideoEncoder(const SdpVideoFormat& format) const override;
+
+  std::unique_ptr<VideoEncoder> CreateVideoEncoder(
+      const SdpVideoFormat& format) override;
 };
 
 class WinUWPH264DecoderFactory : public cricket::WebRtcVideoDecoderFactory {

--- a/third_party/winuwp_h264/winuwp_h264_factory.h
+++ b/third_party/winuwp_h264/winuwp_h264_factory.h
@@ -19,23 +19,7 @@
 
 namespace webrtc {
 
-class WinUWPH264EncoderFactory : public cricket::WebRtcVideoEncoderFactory {
- public:
-  WinUWPH264EncoderFactory();
-
-  webrtc::VideoEncoder* CreateVideoEncoder(const cricket::VideoCodec& codec)
-    override;
-
-  const std::vector<cricket::VideoCodec>& supported_codecs()
-    const override;
-
-  void DestroyVideoEncoder(webrtc::VideoEncoder* encoder) override;
-
- private:
-  std::vector<cricket::VideoCodec> codecList_;
-};
-
-class WinUWPH264EncoderFactoryNew : public VideoEncoderFactory {
+class WinUWPH264EncoderFactory : public VideoEncoderFactory {
  public:
   std::vector<SdpVideoFormat> GetSupportedFormats() const override;
 


### PR DESCRIPTION
The rationale behind this is the ability to use the UWP H264 encoder when building with `rtc_use_builtin_sw_codecs=false` because that flag disables some `CreatePeerconnectionFactory` overloads that take `cricket::WebRtcVideoEncoderFactory` (which is deprecated anyway) instead of `webrtc::VideoEncoderFactory`.

The naming isn't perfect but I thought as long as `cricket::WebRtcVideoEncoderFactory` is still used somewhere in M71 I should not delete it.