### PR TITLE
Added build support for Win H264 Decoder implementation unit tests

### DIFF
--- a/third_party/winuwp_h264/BUILD.gn
+++ b/third_party/winuwp_h264/BUILD.gn
@@ -29,4 +29,7 @@ static_library("winuwp_h264") {
     "//system_wrappers:system_wrappers",
   ]
 
+  if (is_win) {
+    libs = ["runtimeobject.lib"]
+  }
 }

--- a/third_party/winuwp_h264/H264Encoder/H264StreamSink.h
+++ b/third_party/winuwp_h264/H264Encoder/H264StreamSink.h
@@ -42,6 +42,7 @@ enum StreamOperation {
 
 class H264MediaSink;
 
+#pragma warning(disable : 4467)
 [uuid("4b35435f-44ae-44a0-9ba0-b84f9f4a9c19")]
 class IAsyncStreamSinkOperation : public IUnknown {
  public:


### PR DESCRIPTION
This adds the necessary build step for linking the windows runtime library so that the gtest suite can run unit tests against the windows decoder h264. 