### PR TITLE
Added build support for Win H264 Decoder implementation unit tests

### DIFF
--- a/third_party/winuwp_h264/BUILD.gn
+++ b/third_party/winuwp_h264/BUILD.gn
@@ -33,8 +33,9 @@ static_library("winuwp_h264") {
   #Added because of warning C4467: usage of ATL attributes is deprecated.
   #Problem is usage of uuid attribute for IAsyncStreamSinkOperation in H264StreamSink.h file. 
   #It is planned to be modified, so this is temporrary fix. 
-  if (target_os == "winuwp") {
+  if (is_win) {
     cflags = [ "/wd4467" ]
     cflags_cc = [ "/wd4467" ]
+    libs = ["runtimeobject.lib"]
   }
 }


### PR DESCRIPTION
This adds the necessary build step for linking the windows runtime library so that the gtest suite can run unit tests against the windows decoder h264.