### PR TITLE
Configure H264 encoder correctly

### DIFF
--- a/third_party/winuwp_h264/H264Encoder/H264Encoder.h
+++ b/third_party/winuwp_h264/H264Encoder/H264Encoder.h
@@ -86,9 +86,9 @@ class WinUWPH264EncoderImpl : public VideoEncoder, public IH264EncodingCallback 
 
   UINT32 width_;
   UINT32 height_;
-  UINT32 max_frame_rate_;
+  UINT32 frame_rate_;
   UINT32 target_bps_;
-  VideoCodecMode mode_;  
+  VideoCodecMode mode_;
   // H.264 specifc parameters
   bool frame_dropping_on_;
   int key_frame_interval_;


### PR DESCRIPTION
Ensure that the bitrate is higher than 0 so that the encoder works correctly on
Hololens.

Renamed max_frame_rate variable to frame_rate since it is used for the
instantaneous frame rate passed by the WebRTC feedback loop and not just for the
maximum rate.

Should fix https://github.com/microsoft/MixedReality-WebRTC/issues/74.