### PR TITLE
Send ticks to the encoder when dropping frames

### DIFF
--- a/third_party/winuwp_h264/H264Encoder/H264Encoder.cc
+++ b/third_party/winuwp_h264/H264Encoder/H264Encoder.cc
@@ -95,15 +95,18 @@ int WinUWPH264EncoderImpl::InitEncode(const VideoCodec* codec_settings,
     target_bps_ = width_ * height_ * 2;
   }
 
-  return InitEncoderWithSettings(codec_settings);
+  HRESULT hr = S_OK;
+  ON_SUCCEEDED(MFStartup(MF_VERSION));
+
+  ON_SUCCEEDED(InitEncoderWithSettings(codec_settings));
+
+  return hr;
 }
 
 int WinUWPH264EncoderImpl::InitEncoderWithSettings(const VideoCodec* codec_settings) {
   HRESULT hr = S_OK;
 
   rtc::CritScope lock(&crit_);
-
-  ON_SUCCEEDED(MFStartup(MF_VERSION));
 
   // output media type (h264)
   ComPtr<IMFMediaType> mediaTypeOut;
@@ -182,7 +185,7 @@ int WinUWPH264EncoderImpl::RegisterEncodeCompleteCallback(
   return WEBRTC_VIDEO_CODEC_OK;
 }
 
-int WinUWPH264EncoderImpl::Release() {
+int WinUWPH264EncoderImpl::ReleaseWriter() {
   // Use a temporary sink variable to prevent lock inversion
   // between the shutdown call and OnH264Encoded() callback.
   ComPtr<H264MediaSink> tmpMediaSink;
@@ -209,6 +212,13 @@ int WinUWPH264EncoderImpl::Release() {
   if (tmpMediaSink != nullptr) {
     tmpMediaSink->Shutdown();
   }
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int WinUWPH264EncoderImpl::Release() {
+  ReleaseWriter();
+  HRESULT hr = S_OK;
+  ON_SUCCEEDED(MFShutdown());
   return WEBRTC_VIDEO_CODEC_OK;
 }
 
@@ -255,7 +265,7 @@ ComPtr<IMFSample> WinUWPH264EncoderImpl::FromVideoFrame(const VideoFrame& frame)
     {
       if (frameBuffer->width() != (int)width_ || frameBuffer->height() != (int)height_) {
         EncodedImageCallback* tempCallback = encodedCompleteCallback_;
-        Release();
+        ReleaseWriter();
         {
           rtc::CritScope lock(&callbackCrit_);
           encodedCompleteCallback_ = tempCallback;
@@ -535,7 +545,7 @@ int WinUWPH264EncoderImpl::SetRates(
     }
 
     EncodedImageCallback* tempCallback = encodedCompleteCallback_;
-    Release();
+    ReleaseWriter();
     {
       rtc::CritScope lock(&callbackCrit_);
       encodedCompleteCallback_ = tempCallback;

--- a/third_party/winuwp_h264/H264Encoder/H264Encoder.cc
+++ b/third_party/winuwp_h264/H264Encoder/H264Encoder.cc
@@ -98,12 +98,12 @@ int WinUWPH264EncoderImpl::InitEncode(const VideoCodec* codec_settings,
   HRESULT hr = S_OK;
   ON_SUCCEEDED(MFStartup(MF_VERSION));
 
-  ON_SUCCEEDED(InitEncoderWithSettings());
+  ON_SUCCEEDED(InitWriter());
 
   return hr;
 }
 
-int WinUWPH264EncoderImpl::InitEncoderWithSettings() {
+int WinUWPH264EncoderImpl::InitWriter() {
   HRESULT hr = S_OK;
 
   rtc::CritScope lock(&crit_);
@@ -269,7 +269,7 @@ ComPtr<IMFSample> WinUWPH264EncoderImpl::FromVideoFrame(const VideoFrame& frame)
 
         width_ = frameBuffer->width();
         height_ = frameBuffer->height();
-        InitEncoderWithSettings();
+        InitWriter();
         RTC_LOG(LS_WARNING) << "Resolution changed to: " << frameBuffer->width() << "x" << frameBuffer->height();
       }
     }
@@ -318,8 +318,11 @@ ComPtr<IMFSample> WinUWPH264EncoderImpl::FromVideoFrame(const VideoFrame& frame)
   return sample;
 }
 
+// Returns the timestamp in hundreds of nanoseconds (Media Foundation unit)
 LONGLONG WinUWPH264EncoderImpl::GetFrameTimestampHns(const VideoFrame& frame) const {
-  return ((frame.timestamp() - startTime_) / 90) * 1000 * 10;
+  // H.264 clock rate is 90kHz (https://tools.ietf.org/html/rfc6184#page-11).
+  // timestamp_100ns = timestamp_90kHz / {90'000 Hz} * {10'000'000 hns/sec}
+  return (frame.timestamp() - startTime_) * 10'000 / 90;
 }
 
 int WinUWPH264EncoderImpl::Encode(
@@ -559,7 +562,7 @@ int WinUWPH264EncoderImpl::SetRates(
       rtc::CritScope lock(&callbackCrit_);
       encodedCompleteCallback_ = tempCallback;
     }
-    InitEncoderWithSettings();
+    InitWriter();
   }
 
   return WEBRTC_VIDEO_CODEC_OK;

--- a/third_party/winuwp_h264/H264Encoder/H264Encoder.h
+++ b/third_party/winuwp_h264/H264Encoder/H264Encoder.h
@@ -56,7 +56,7 @@ class WinUWPH264EncoderImpl : public VideoEncoder, public IH264EncodingCallback 
 
  private:
   ComPtr<IMFSample> FromVideoFrame(const VideoFrame& frame);
-  int InitEncoderWithSettings(const VideoCodec* codec_settings);
+  int InitEncoderWithSettings();
   int ReleaseWriter();
   LONGLONG GetFrameTimestampHns(const VideoFrame& frame) const;
 
@@ -66,8 +66,6 @@ class WinUWPH264EncoderImpl : public VideoEncoder, public IH264EncodingCallback 
   bool inited_ {};
   const CodecSpecificInfo* codecSpecificInfo_ {};
   ComPtr<IMFSinkWriter> sinkWriter_;
-  ComPtr<IMFAttributes> sinkWriterCreationAttributes_;
-  ComPtr<IMFAttributes> sinkWriterEncoderAttributes_;
   ComPtr<H264MediaSink> mediaSink_;
   EncodedImageCallback* encodedCompleteCallback_ {};
   DWORD streamIndex_ {};
@@ -106,8 +104,6 @@ class WinUWPH264EncoderImpl : public VideoEncoder, public IH264EncodingCallback 
   };
   SampleAttributeQueue<CachedFrameAttributes> _sampleAttributeQueue;
 
-  // Caching the codec received in InitEncode().
-  VideoCodec codec_;
 };  // end of WinUWPH264EncoderImpl class
 
 }  // namespace webrtc

--- a/third_party/winuwp_h264/H264Encoder/H264Encoder.h
+++ b/third_party/winuwp_h264/H264Encoder/H264Encoder.h
@@ -56,7 +56,7 @@ class WinUWPH264EncoderImpl : public VideoEncoder, public IH264EncodingCallback 
 
  private:
   ComPtr<IMFSample> FromVideoFrame(const VideoFrame& frame);
-  int InitEncoderWithSettings();
+  int InitWriter();
   int ReleaseWriter();
   LONGLONG GetFrameTimestampHns(const VideoFrame& frame) const;
 

--- a/third_party/winuwp_h264/H264Encoder/H264Encoder.h
+++ b/third_party/winuwp_h264/H264Encoder/H264Encoder.h
@@ -57,6 +57,7 @@ class WinUWPH264EncoderImpl : public VideoEncoder, public IH264EncodingCallback 
  private:
   ComPtr<IMFSample> FromVideoFrame(const VideoFrame& frame);
   int InitEncoderWithSettings(const VideoCodec* codec_settings);
+  int ReleaseWriter();
 
  private:
   rtc::CriticalSection crit_;

--- a/third_party/winuwp_h264/H264Encoder/H264Encoder.h
+++ b/third_party/winuwp_h264/H264Encoder/H264Encoder.h
@@ -58,6 +58,7 @@ class WinUWPH264EncoderImpl : public VideoEncoder, public IH264EncodingCallback 
   ComPtr<IMFSample> FromVideoFrame(const VideoFrame& frame);
   int InitEncoderWithSettings(const VideoCodec* codec_settings);
   int ReleaseWriter();
+  LONGLONG GetFrameTimestampHns(const VideoFrame& frame) const;
 
  private:
   rtc::CriticalSection crit_;


### PR DESCRIPTION
Mitigates https://github.com/microsoft/MixedReality-WebRTC/issues/74.

Merged some small refactorings too which don't change behavior.