### PR TITLE
Fix invalid H.264 decoder output frame size

### DIFF
--- a/third_party/winuwp_h264/H264Decoder/H264Decoder.cc
+++ b/third_party/winuwp_h264/H264Decoder/H264Decoder.cc
@@ -38,10 +38,10 @@ namespace webrtc {
 //////////////////////////////////////////
 
 WinUWPH264DecoderImpl::WinUWPH264DecoderImpl()
-    : buffer_pool_(false, 300), /* max_number_of_buffers*/ 
+    : buffer_pool_(false, 300), /* max_number_of_buffers*/
       width_(absl::nullopt),
       height_(absl::nullopt),
-      decode_complete_callback_(nullptr){}
+      decode_complete_callback_(nullptr) {}
 
 WinUWPH264DecoderImpl::~WinUWPH264DecoderImpl() {
   OutputDebugString(L"WinUWPH264DecoderImpl::~WinUWPH264DecoderImpl()\n");
@@ -282,33 +282,41 @@ HRESULT WinUWPH264DecoderImpl::FlushFrames(uint32_t rtp_timestamp,
       return hr;
     }
 
-    uint32_t width, height;
-    if (width_.has_value() && height_.has_value()) {
-      width = width_.value();
-      height = height_.value();
-    } else {
-      // Query the size from MF output media type
+    uint32_t width, height, buffer_width, buffer_height;
+    {
+      // Get the output media type
       ComPtr<IMFMediaType> output_type;
       ON_SUCCEEDED(
           decoder_->GetOutputCurrentType(0, output_type.GetAddressOf()));
 
+      // Query the actual buffer size to get the stride and vertical padding, so
+      // the UV plane can be accessed at the right offset.
       ON_SUCCEEDED(MFGetAttributeSize(output_type.Get(), MF_MT_FRAME_SIZE,
-                                      &width, &height));
-      if (FAILED(hr)) {
-        RTC_LOG(LS_ERROR) << "Decode failure: could not read image dimensions "
-                             "from Media Foundation, so the video frame buffer "
-                             "size can not be determined.";
-        return hr;
+                                      &buffer_width, &buffer_height));
+
+      // Query the visible area of the frame, which is the data that must be
+      // returned to the caller. Sometimes this attribute is not present, and in
+      // general this means that the frame size is not padded.
+      MFVideoArea video_area;
+      if (SUCCEEDED(output_type->GetBlob(MF_MT_MINIMUM_DISPLAY_APERTURE,
+                                         (UINT8*)&video_area,
+                                         sizeof(video_area), nullptr))) {
+        width = video_area.Area.cx;
+        height = video_area.Area.cy;
+      } else {
+        // Fallback to buffer size
+        width = buffer_width;
+        height = buffer_height;
       }
 
-      // Update members to avoid querying unnecessarily
+      // Update cached values
       width_.emplace(width);
       height_.emplace(height);
     }
 
+    // Create a new I420 buffer to pass to WebRTC
     rtc::scoped_refptr<I420Buffer> buffer =
         buffer_pool_.CreateBuffer(width, height);
-
     if (!buffer.get()) {
       // Pool has too many pending frames.
       RTC_LOG(LS_WARNING) << "Decode warning: too many frames. Dropping frame.";
@@ -334,11 +342,13 @@ HRESULT WinUWPH264DecoderImpl::FlushFrames(uint32_t rtp_timestamp,
       // Convert NV12 to I420. Y and UV sections have same stride in NV12
       // (width). The size of the Y section is the size of the frame, since Y
       // luminance values are 8-bits each.
-      libyuv::NV12ToI420(src_data, width, src_data + (width * height), width,
-                         buffer->MutableDataY(), buffer->StrideY(),
-                         buffer->MutableDataU(), buffer->StrideU(),
-                         buffer->MutableDataV(), buffer->StrideV(), width,
-                         height);
+      const int src_stride_y = buffer_width;
+      const int src_stride_uv = buffer_width;
+      const uint8_t* src_uv = src_data + (src_stride_y * buffer_height);
+      libyuv::NV12ToI420(
+          src_data, src_stride_y, src_uv, src_stride_uv, buffer->MutableDataY(),
+          buffer->StrideY(), buffer->MutableDataU(), buffer->StrideU(),
+          buffer->MutableDataV(), buffer->StrideV(), width, height);
 
       ON_SUCCEEDED(src_buffer->Unlock());
       if (FAILED(hr))
@@ -551,7 +561,7 @@ int WinUWPH264DecoderImpl::Release() {
 
   // Release I420 frame buffer pool
   buffer_pool_.Release();
-  
+
   if (decoder_ != NULL) {
     // Follow shutdown procedure gracefully. On fail, continue anyway.
     ON_SUCCEEDED(decoder_->ProcessMessage(MFT_MESSAGE_NOTIFY_END_OF_STREAM, 0));


### PR DESCRIPTION
When the H.264 decoder returns a decoded frame, the frame might contain
the MF_MT_MINIMUM_DISPLAY_APERTURE attribute. In that case, this
indicates that the frame buffer is padded, and gives the visible area
inside the buffer. Conversely the MF_MT_FRAME_SIZE always gives the
total buffer size. Both are needed to safely access the data in the
buffer and convert it to I420, but the output frame needs to have the
size of the former, the visible area.