### PR TITLE
Improve dynamic rate change in H264 encoder 

### DIFF
--- a/third_party/winuwp_h264/H264Encoder/H264Encoder.h
+++ b/third_party/winuwp_h264/H264Encoder/H264Encoder.h
@@ -59,6 +59,10 @@ class WinUWPH264EncoderImpl : public VideoEncoder, public IH264EncodingCallback 
   int InitWriter();
   int ReleaseWriter();
   LONGLONG GetFrameTimestampHns(const VideoFrame& frame) const;
+  int ReconfigureSinkWriter(UINT32 new_width,
+                            UINT32 new_height,
+                            UINT32 new_target_bps,
+                            UINT32 new_frame_rate);
 
  private:
   rtc::CriticalSection crit_;
@@ -93,7 +97,12 @@ class WinUWPH264EncoderImpl : public VideoEncoder, public IH264EncodingCallback 
   bool frame_dropping_on_;
   int key_frame_interval_;
 
-  int64_t lastTimeSettingsChanged_ {};
+  int64_t last_rate_change_time_rtc_ms {};
+  bool rate_change_requested_ {};
+
+  // Values to use as soon as the min interval between rate changes has passed
+  UINT32 next_frame_rate_;
+  UINT32 next_target_bps_;
 
   struct CachedFrameAttributes {
     uint32_t timestamp;

--- a/third_party/winuwp_h264/H264Encoder/H264MediaSink.cc
+++ b/third_party/winuwp_h264/H264Encoder/H264MediaSink.cc
@@ -20,7 +20,6 @@ H264MediaSink::H264MediaSink()
 
 
 H264MediaSink::~H264MediaSink() {
-  OutputDebugString(L"H264MediaSink::~H264MediaSink()\r\n");
 }
 
 HRESULT H264MediaSink::RuntimeClassInitialize() {

--- a/third_party/winuwp_h264/H264Encoder/H264StreamSink.cc
+++ b/third_party/winuwp_h264/H264Encoder/H264StreamSink.cc
@@ -29,7 +29,6 @@ H264StreamSink::H264StreamSink()
 }
 
 H264StreamSink::~H264StreamSink() {
-  OutputDebugString(L"H264StreamSink::~H264StreamSink()\r\n");
 }
 
 HRESULT H264StreamSink::RuntimeClassInitialize(


### PR DESCRIPTION
This change fixes the following issues:
* Rate changes requested before the minimum interval has passed are not ignored
anymore. Instead, they are executed in Encode when the minimum interval has
passed. This way there is no risk of ignoring a significant rate change anymore.
Small rate changes are still ignored so that streaming does not stutter too much
at steady state on e.g. HL1.
* The minimum interval is now 5s down from 15s so the stream gets to full speed
in a more reasonable time.

Improves microsoft/MixedReality-WebRTC#107