### PR TITLE
Set the default behavior to no pad/crop

### DIFF
--- a/third_party/winuwp_h264/H264Encoder/H264Encoder.h
+++ b/third_party/winuwp_h264/H264Encoder/H264Encoder.h
@@ -90,7 +90,6 @@ class WinUWPH264EncoderImpl : public VideoEncoder, public IH264EncodingCallback 
 
   UINT32 width_;
   UINT32 height_;
-  UINT32 encoded_height_;
   UINT32 frame_rate_;
   UINT32 target_bps_;
   VideoCodecMode mode_;


### PR DESCRIPTION
Controlling the workaround from user code makes it easier to change it later.